### PR TITLE
New cutoff.perc argument on calc_auc

### DIFF
--- a/tests/testthat/test-calc.R
+++ b/tests/testthat/test-calc.R
@@ -126,5 +126,5 @@ test_that(desc = "Calc AUC works for specific cut-offs", {
   auc1 <- calc_auc(p1)
   auc2 <- calc_auc(p1, 0.25)
 
-  expect_true(all(auc1$AUC - auc2$AUC - 0.75 < 0.1))
+  expect_true(all(auc1$AUC - auc2$AUC - 0.75 < 0.01))
 })

--- a/tests/testthat/test-calc.R
+++ b/tests/testthat/test-calc.R
@@ -115,3 +115,16 @@ test_that(desc = "Calc AUC works for data passed within geom_roc, and multiple r
   
 })
 
+test_that(desc = "Calc AUC works for specific cut-offs", {
+  set.seed(123)
+  x <- runif(1000)
+  y <- round(x)
+  df <- data.frame(x, y, gp = c("A", "B"))
+
+  p1 <- ggplot(df, aes(d = y, m = x, color = gp)) + geom_roc()
+
+  auc1 <- calc_auc(p1)
+  auc2 <- calc_auc(p1, 0.25)
+
+  expect_true(all(auc1$AUC - auc2$AUC - 0.75 < 0.1))
+})

--- a/vignettes/examples.Rmd
+++ b/vignettes/examples.Rmd
@@ -255,10 +255,15 @@ calc_auc(bygend2)
 
 ```
 
+May be usefull to calc AUC only for top scoring records.
+
+```{r auctab2}
+calc_auc(bygend2, cutoff.perc = 0.05)
+```
 
 Also works for multiple panels, and layers. 
 
-```{r auctab2}
+```{r auctab3}
 set.seed(123)
 x <- rnorm(100)
 y <- round(plogis(3*x + rnorm(100, sd = 5)))


### PR DESCRIPTION
Hi,

I never commited to a R repo and don't develop with base R because I use mostly tidyverse and related packages, so be gentle.

Yesterday I noticed that `plotROC` don't have support to compute the AUC curve for the top scoring observations, which is useful in areas like molecular virtual screening, so managed the `cutoff.perc` argument on `calc_auc` function. I didn't managed to got man pages built. 

And some questions now:
* I use the FPR value as the one to apply the cut-off. Is this correct?
* Why are the `PANEL` and `group` columns present on the dataframe returned by `calc_auc` ?
* The plot "resolution" is 1000 points. If my data is too big to fit in, how the" downscaling" works?