### PR TITLE
Make it work with single class or empty groups

### DIFF
--- a/R/calculate_roc.R
+++ b/R/calculate_roc.R
@@ -145,18 +145,26 @@ calculate_multi_roc <- function(data, M_string, D_string){
 #' }
 #' 
 verify_d <- function(D){
+  
+  lev <- levels(as.factor(D))
 
-  if(length(levels(as.factor(D))) > 2) stop("Only labels with 2 classes supported")
-  
-  slev <- sort(levels(as.factor(D)))
-  if(slev[1] == 0 & slev[2] == 1) return(D)
-  
-  warning(paste0("D not labeled 0/1, assuming ", slev[1], " = 0 and ", slev[2], " = 1!"))
-  
-  zero1 <- c(0, 1)
-  names(zero1) <- slev
-  
-  zero1[as.character(D)]
+  if (length(lev) > 2) {
+    stop("Only labels with 2 classes supported")
+  }
+  else if (length(lev) < 2) {
+    warning("Single class or empty group detected. Proceeding with an empty plot.")
+    return(D)
+  }
+  else {
+    slev <- sort(lev)
+    if(slev[1] == 0 & slev[2] == 1) {
+      return(D)
+    }
+    warning(paste0("D not labeled 0/1, assuming ", slev[1], " = 0 and ", slev[2], " = 1!"))
+    zero1 <- c(0, 1)
+    names(zero1) <- slev
+    zero1[as.character(D)]
+  }
   
 }
 

--- a/tests/testthat/test-calc.R
+++ b/tests/testthat/test-calc.R
@@ -128,3 +128,13 @@ test_that(desc = "Calc AUC works for specific cut-offs", {
 
   expect_true(all(auc1$AUC - auc2$AUC - 0.75 < 0.01))
 })
+
+
+test_that(desc = "Single class or empty group works", {
+  set.seed(123)
+  x <- runif(1)
+  y <- round(x)
+  df <- data.frame(x, y)
+  p1 <- ggplot(df, aes(d = y, m = x)) + geom_roc()
+  expect_warning(print(p1), "Single class or empty group detected. Proceeding with an empty plot.")
+})

--- a/tests/testthat/test-calc.R
+++ b/tests/testthat/test-calc.R
@@ -126,5 +126,5 @@ test_that(desc = "Calc AUC works for specific cut-offs", {
   auc1 <- calc_auc(p1)
   auc2 <- calc_auc(p1, 0.25)
 
-  expect_true(all(auc1$AUC - auc2$AUC - 0.75 < 0.1))
+  expect_true(all(auc1$AUC - auc2$AUC - 0.75 < 0.01))
 })

--- a/tests/testthat/test-calc.R
+++ b/tests/testthat/test-calc.R
@@ -115,3 +115,16 @@ test_that(desc = "Calc AUC works for data passed within geom_roc, and multiple r
   
 })
 
+test_that(desc = "Calc AUC works for specific cut-offs", {
+  set.seed(123)
+  x <- runif(1000)
+  y <- round(x)
+  df <- data.frame(x, y, gp = c("A", "B"))
+
+  p1 <- ggplot(df, aes(d = y, m = x, color = gp)) + geom_roc()
+
+  auc1 <- calc_auc(p1)
+  auc2 <- calc_auc(p1, 0.25)
+
+  expect_true(all(auc1$AUC - auc2$AUC - 0.75 < 0.1))
+})

--- a/vignettes/examples.Rmd
+++ b/vignettes/examples.Rmd
@@ -255,10 +255,15 @@ calc_auc(bygend2)
 
 ```
 
+May be usefull to calc AUC only for top scoring records.
+
+```{r auctab2}
+calc_auc(bygend2, cutoff.perc = 0.05)
+```
 
 Also works for multiple panels, and layers. 
 
-```{r auctab2}
+```{r auctab3}
 set.seed(123)
 x <- rnorm(100)
 y <- round(plogis(3*x + rnorm(100, sd = 5)))


### PR DESCRIPTION
When there is a single class on data or the group is empty, `verify_d` fails with an error (not an explicit error but a logic one) because it cannot guess the binary classes. But the desired behavior is to produce an empty plot.
```
Error in `geom_roc()`: Problem while computing stat.
ℹ Error occurred in the 1st layer.
Caused by error in `if (slev[1] == 0 & slev[2] == 1) ...`:
! missing value where TRUE/FALSE needed
```

This was a problem for me when attempting to `calc_auc(p)` on an empty group and didn't received NA as expected.